### PR TITLE
Make ant projects to use ProcessRunner

### DIFF
--- a/tmc-langs-framework/src/main/java/fi/helsinki/cs/tmc/langs/utils/ProcessRunner.java
+++ b/tmc-langs-framework/src/main/java/fi/helsinki/cs/tmc/langs/utils/ProcessRunner.java
@@ -28,7 +28,7 @@ public final class ProcessRunner implements Callable<ProcessResult> {
     }
 
     @Override
-    public ProcessResult call() throws Exception {
+    public ProcessResult call() throws IOException, InterruptedException {
         Process process = null;
         try {
             ProcessBuilder processBuilder = new ProcessBuilder(command);

--- a/tmc-langs-java/src/main/java/fi/helsinki/cs/tmc/langs/java/ant/TestRunnerArgumentBuilder.java
+++ b/tmc-langs-java/src/main/java/fi/helsinki/cs/tmc/langs/java/ant/TestRunnerArgumentBuilder.java
@@ -86,9 +86,9 @@ public final class TestRunnerArgumentBuilder {
     }
 
     /**
-     * Get the arguments as a list of Strings, usable with ProcessBuilder.
+     * Get the command with the arguments as a string array. This can be used to start the process.
      */
-    public List<String> getArguments() {
-        return arguments;
+    public String[] getCommand() {
+        return arguments.toArray(new String[0]);
     }
 }

--- a/tmc-langs-java/src/main/java/fi/helsinki/cs/tmc/langs/java/maven/MavenInvokatorMavenTaskRunner.java
+++ b/tmc-langs-java/src/main/java/fi/helsinki/cs/tmc/langs/java/maven/MavenInvokatorMavenTaskRunner.java
@@ -97,11 +97,12 @@ public class MavenInvokatorMavenTaskRunner implements MavenTaskRunner {
 
     private Path useBundledMaven() {
         Path mavenHome = getConfigDirectory();
-        if (Files.exists(mavenHome)) {
+        Path extractedMavenLocation = mavenHome.resolve("apache-maven-3.3.9");
+        if (Files.exists(extractedMavenLocation)) {
             log.info("Maven already extracted");
 
             // Add the name of the extracted folder to the path
-            return mavenHome.resolve("apache-maven-3.3.9");
+            return extractedMavenLocation;
         }
         log.info("Maven bundle not previously extracted, extracting...");
         try {


### PR DESCRIPTION
This refactoring ensures the working directory is always correct for the test process.

Also fixed some extraction problems with the maven bundle.