### PR TITLE
Minor fix: have UnzipResult::toString include all fields

### DIFF
--- a/tmc-langs-framework/src/main/java/fi/helsinki/cs/tmc/langs/io/zip/UnzipResult.java
+++ b/tmc-langs-framework/src/main/java/fi/helsinki/cs/tmc/langs/io/zip/UnzipResult.java
@@ -48,12 +48,13 @@ public class UnzipResult {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
+        sb.append("Project: \"").append(projectDir).append("\"\n");
         sb.append("New: ").append(newFiles).append('\n');
         sb.append("Overwritten: ").append(overwrittenFiles).append('\n');
         sb.append("Skipped: ").append(skippedFiles).append('\n');
         sb.append("Unchanged: ").append(unchangedFiles).append('\n');
         sb.append("Deleted: ").append(deletedFiles).append('\n');
-        sb.append("Not deleted: ").append(deletedFiles).append('\n');
+        sb.append("Not deleted: ").append(skippedDeletingFiles).append('\n');
         return sb.toString();
     }
 }

--- a/tmc-langs-framework/src/test/java/fi/helsinki/cs/tmc/langs/io/zip/UnzipResultTest.java
+++ b/tmc-langs-framework/src/test/java/fi/helsinki/cs/tmc/langs/io/zip/UnzipResultTest.java
@@ -1,0 +1,42 @@
+package fi.helsinki.cs.tmc.langs.io.zip;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UnzipResultTest {
+
+    @Test
+    public void unzipResultToStringContainsExpectedPaths() {
+        final List<Path> expected = new ArrayList<>();
+
+        Path projectPath = Paths.get("./test/");
+        UnzipResult result = new UnzipResult(projectPath);
+        expected.add(projectPath);
+        addItemToBoth(Paths.get("test/Toaster.java"), expected, result.newFiles);
+        addItemToBoth(Paths.get("test/Overwritten.java"), expected, result.overwrittenFiles);
+        addItemToBoth(Paths.get("test/Test.iml"), expected, result.skippedFiles);
+        addItemToBoth(Paths.get("test/bar/Foo.java"), expected, result.unchangedFiles);
+        addItemToBoth(Paths.get("test/target/Thing.jar"), expected, result.deletedFiles);
+        addItemToBoth(Paths.get("test/target/Report.xml"), expected, result.skippedDeletingFiles);
+
+        String resultString = result.toString();
+
+        for (Path path : expected) {
+            String pathString = path.toString();
+            assertTrue(
+                    "Expected UnzipResult to contain path \"" + pathString + "\"",
+                    resultString.contains(pathString));
+        }
+    }
+
+    private static <T> void addItemToBoth(T item, List<T> first, List<T> second) {
+        first.add(item);
+        second.add(item);
+    }
+}


### PR DESCRIPTION
`project` and `skippedDeletedFiles` were not included previously.