### PR TITLE
Utils tarball extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ __pycache__/
 
 /tmc-langs-java/src/main/resources/tmc-junit-runner.jar
 /tmc-langs-java/src/test/resources/exit_zero/build/
+

--- a/tmc-langs-util/pom.xml
+++ b/tmc-langs-util/pom.xml
@@ -78,6 +78,13 @@
             <version>${project.version}</version>
             <type>jar</type>
         </dependency>
+        <!-- tar handling -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.14</version>
+            <type>jar</type>
+        </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>

--- a/tmc-langs-util/src/main/java/fi/helsinki/cs/tmc/langs/util/TaskExecutor.java
+++ b/tmc-langs-util/src/main/java/fi/helsinki/cs/tmc/langs/util/TaskExecutor.java
@@ -10,6 +10,8 @@ import fi.helsinki.cs.tmc.langs.domain.RunResult;
 import com.google.common.annotations.Beta;
 import com.google.common.base.Optional;
 
+import org.apache.commons.compress.archivers.ArchiveException;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Locale;
@@ -116,6 +118,18 @@ public interface TaskExecutor {
 
     ExercisePackagingConfiguration getExercisePackagingConfiguration(Path path)
             throws NoLanguagePluginFoundException;
+
+    /**
+     * Creates a tarball that can be submitted to TMC-sandbox.
+     * The tar is created to the target location
+     * 
+     * @param projectDir Location of the unzipped project
+     * @param tmcLangs Location of tmc-langs-cli.jar
+     * @param tmcrun Location of tmc-run init script
+     * @param targetLocation Location where the tar archive should be extracted to
+     */
+    void compressTarForSubmitting(Path projectDir, Path tmcLangs, Path tmcrun, Path targetLocation)
+            throws IOException, ArchiveException;
 
     /**
      * Run clean for given path using proper language plugin.

--- a/tmc-langs-util/src/main/java/fi/helsinki/cs/tmc/langs/util/TaskExecutorImpl.java
+++ b/tmc-langs-util/src/main/java/fi/helsinki/cs/tmc/langs/util/TaskExecutorImpl.java
@@ -11,9 +11,11 @@ import fi.helsinki.cs.tmc.langs.io.EverythingIsStudentFileStudentFilePolicy;
 import fi.helsinki.cs.tmc.langs.io.NothingIsStudentFileStudentFilePolicy;
 import fi.helsinki.cs.tmc.langs.io.zip.StudentFileAwareUnzipper;
 import fi.helsinki.cs.tmc.langs.io.zip.Unzipper;
+import fi.helsinki.cs.tmc.langs.util.tarservice.TarCreator;
 
 import com.google.common.base.Optional;
 
+import org.apache.commons.compress.archivers.ArchiveException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +116,14 @@ public class TaskExecutorImpl implements TaskExecutor {
     public ExercisePackagingConfiguration getExercisePackagingConfiguration(Path path)
             throws NoLanguagePluginFoundException {
         return getLanguagePlugin(path).getExercisePackagingConfiguration();
+    }
+
+    @Override
+    public void compressTarForSubmitting(Path projectDir, Path tmcLangs,
+            Path tmcrun, Path targetLocation) throws IOException, ArchiveException {
+        TarCreator tarCompresser = new TarCreator();
+        log.info("Copying files to directory " + projectDir.toString() + " and creating tar ball");
+        tarCompresser.createTarFromProject(projectDir, tmcLangs, tmcrun, targetLocation);
     }
 
     @Override

--- a/tmc-langs-util/src/main/java/fi/helsinki/cs/tmc/langs/util/tarservice/TarCreator.java
+++ b/tmc-langs-util/src/main/java/fi/helsinki/cs/tmc/langs/util/tarservice/TarCreator.java
@@ -1,0 +1,81 @@
+package fi.helsinki.cs.tmc.langs.util.tarservice;
+
+import static org.apache.commons.compress.archivers.tar.TarArchiveOutputStream.LONGFILE_POSIX;
+
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class TarCreator {
+
+    /**
+     * Copies the location of tmc-langs-cli and tmcrun to unzipped project folder
+     * and creates a tarball.
+     *
+     * @param projectDir     Location of unzipped project dir
+     * @param tmcLangs       Location of tmc-langs-cli.jar
+     * @param tmcrun         Location of tmc-run init script
+     * @param targetLocation Location where the tar archive should be extracted to
+     * @throws IOException      Error!
+     * @throws ArchiveException Error!
+     */
+    public void createTarFromProject(Path projectDir, Path tmcLangs, Path tmcrun,
+                                     Path targetLocation) throws IOException, ArchiveException {
+        Files.copy(tmcrun, projectDir.resolve(tmcrun.getFileName()));
+        Files.copy(tmcLangs, projectDir.resolve(tmcLangs.getFileName()));
+        createTarBall(projectDir, targetLocation);
+    }
+
+    /**
+     * Creates a tarball from a directory.
+     *
+     * @param project        Project directory file
+     * @param targetLocation Location where the tar archive should be extracted to
+     * @throws IOException      Error!
+     * @throws ArchiveException Error!
+     */
+    private void createTarBall(Path project, Path targetLocation)
+            throws IOException, ArchiveException {
+        try (FileOutputStream tarOut = new FileOutputStream(targetLocation.toString())) {
+            try (TarArchiveOutputStream aos = new TarArchiveOutputStream(tarOut)) {
+                aos.setLongFileMode(LONGFILE_POSIX);
+                addFilesToTarBall(project, aos, project);
+                aos.finish();
+            }
+        }
+    }
+
+    /**
+     * Adds all files and folders inside a folder to a tar file.
+     *
+     * @param folder       The folder to add
+     * @param tar          TarArchiveOutputStreamer tar
+     * @param lengthOfPath The length of String from root until the start folder.
+     * @throws FileNotFoundException Error!
+     * @throws IOException           Error!
+     */
+    private void addFilesToTarBall(Path folder, TarArchiveOutputStream tar,
+                                   Path basePath) throws FileNotFoundException, IOException {
+        for (Path path : Files.newDirectoryStream(folder)) {
+            if (Files.isDirectory(path)) {
+                addFilesToTarBall(path, tar, basePath);
+            } else {
+                TarArchiveEntry entry = new TarArchiveEntry(basePath.relativize(path).toString());
+                entry.setSize(path.toFile().length());
+                tar.putArchiveEntry(entry);
+                try (FileInputStream fis = new FileInputStream(path.toFile())) {
+                    IOUtils.copy(fis, tar);
+                }
+                tar.closeArchiveEntry();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tarball creator extension for tmc-langs-util. Creates a tarball that can be sent to TMC-sandbox for testing.

The created tarball has been tested locally and should be similar to the one created by TMC-Server.