### PR TITLE
Quicktest fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,9 +17,12 @@ Build the project with `mvn clean package`. Install the dependency to your local
 ## Test
 
 Test the project with `mvn test`.
-For the tmc-langs-java maven tests to pass it either needs to be invoced with mvn exec magic, like NetBeans does it. However, when executed from commandline `M3_HOME` must be configured. Either via `$M3_HOME` or from mavens configuration files.
+For the tmc-langs-java maven tests to pass it either needs to be invoked with mvn exec magic, like NetBeans does it. However, when executed from commandline `M3_HOME` must be configured. Either via `$M3_HOME` or from mavens configuration files.
 
-For running tests for the `tmc-langs-python` `python` executable must be accessible from your `$PATH` and for the `tmc-langs-rust` `rust` and rust-package-manager executables must be accessible from your `$PATH`.
+Running tests for:
+- `tmc-langs-python`: `python` executable must be accessible from your `$PATH`
+- `tmc-langs-rust`: `rust` and rust-package-manager executables must be accessible from your `$PATH`.
+- `tmc-langs-qmake`: a valid Qt install with `qmake` executable must be accessible from your `$PATH` and `$QT_QPA_PLATFORM` set to `minimal`
 
 ## Usage
 

--- a/tmc-langs-qmake/pom.xml
+++ b/tmc-langs-qmake/pom.xml
@@ -43,12 +43,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/make-project/**/*</exclude>
-                        <exclude>**/eRror/**/*</exclude>
-                    </excludes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/tmc-langs-qmake/src/main/java/fi/helsinki/cs/tmc/langs/qmake/QmakePlugin.java
+++ b/tmc-langs-qmake/src/main/java/fi/helsinki/cs/tmc/langs/qmake/QmakePlugin.java
@@ -203,11 +203,11 @@ public final class QmakePlugin extends AbstractLanguagePlugin {
         try {
             ProcessResult testRun = run(makeCommand, shadowDir);
 
-            if (!Files.exists(testResults)) {
+            if (!Files.exists(testResults) || Files.size(testResults) == 0) {
                 log.error("Failed to get test output at {}", testResults);
                 log.error("Test stdout\n {}", testRun.output);
                 log.error("Test stderr\n {}", testRun.errorOutput);
-                return filledFailure(Status.GENERIC_ERROR, testRun.output);
+                return filledFailure(Status.COMPILE_FAILED, testRun.errorOutput);
             }
         } catch (IOException | InterruptedException e) {
             log.error("Testing with make check failed", e);
@@ -305,8 +305,8 @@ public final class QmakePlugin extends AbstractLanguagePlugin {
      * </p>
      * <p>QUICKTEST_POINT_PATTERN matches the QML js syntax: </p>
      * <p>
-     *      qmlPOINT("test_name", "1.1");
-     *      qmlPOINT("test_name2", "point");
+     *      quickPOINT("test_name", "1.1");
+     *      quickPOINT("test_name2", "point");
      * </p>
      */
     public Optional<ImmutableList<TestDesc>> availablePoints(final Path rootPath) {

--- a/tmc-langs-qmake/src/test/java/fi/helsinki/cs/tmc/langs/qmake/QmakePluginTest.java
+++ b/tmc-langs-qmake/src/test/java/fi/helsinki/cs/tmc/langs/qmake/QmakePluginTest.java
@@ -173,6 +173,15 @@ public class QmakePluginTest {
     }
 
     @Test
+    public void testQuickTestsInvalidQuickProject() {
+        Assume.assumeTrue("Set QT_QPA_PLATFORM if testing quick project build",
+                System.getenv("QT_QPA_PLATFORM") != null);
+        RunResult result = runTests(TestUtils.getPath(getClass(),"invalid_quick_project"));
+        assertEquals("Compile should be failing with invalid component",
+                RunResult.Status.COMPILE_FAILED, result.status);
+    }
+
+    @Test
     public void testScanInvalidMakefileExercise() {
         Optional<ExerciseDesc> optional = scanExercise("makefile");
         assertFalse(optional.isPresent());
@@ -295,6 +304,8 @@ public class QmakePluginTest {
         assertTrue(isExerciseTypeCorrect("failing_single_lib"));
         assertTrue(isExerciseTypeCorrect("failing_single_lib_not_compiling"));
         assertTrue(isExerciseTypeCorrect("failing_single_lib_same_point"));
+        assertTrue(isExerciseTypeCorrect("quick_project"));
+        assertTrue(isExerciseTypeCorrect("invalid_quick_project"));
         assertFalse(isExerciseTypeCorrect("makefile"));
         assertFalse(isExerciseTypeCorrect(""));
     }

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/Clicker.pro
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/Clicker.pro
@@ -1,0 +1,6 @@
+TEMPLATE = subdirs
+SUBDIRS += \
+        src \
+        test_runner
+
+        test_runner.depends = src

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/Clicker.qml
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/Clicker.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.9
+
+Item {
+    // dummy item
+}

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/main.cpp
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/main.cpp
@@ -1,0 +1,15 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+    QGuiApplication app(argc, argv);
+
+    QQmlApplicationEngine engine;
+    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
+    if (engine.rootObjects().isEmpty())
+        return -1;
+    return app.exec();
+}

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/main.qml
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/main.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.0
+import QtQuick.Window 2.2
+
+Window {
+    id: window
+    width: 620
+    visible: true
+    height: 420
+
+    Clicker {
+        width: 350
+        height: 200
+        anchors.centerIn: parent
+    }
+
+}

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/qml.qrc
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/qml.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/">
+        <file>main.qml</file>
+        <file>Clicker.qml</file>
+    </qresource>
+</RCC>

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/src.pro
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/src/src.pro
@@ -1,0 +1,13 @@
+QT += quick
+TARGET = clicker
+CONFIG += c++11
+
+DEFINES += QT_DEPRECATED_WARNINGS
+
+SOURCES += main.cpp
+
+RESOURCES += qml.qrc
+
+OTHER_FILES += \
+    Clicker.qml \
+    main.qml

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/ClickerTest.qml
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/ClickerTest.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import "../src" 1.00
 
 Clicker {
+    // Invalid test file, property not found
     clickedType: "Click"
     width: 350
     height: 200

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/test_runner.pro
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/test_runner.pro
@@ -1,0 +1,18 @@
+TEMPLATE = app
+TARGET = tst_clicker
+QT += quick core testlib
+CONFIG += c++11 warn_on qmltestcase
+CONFIG -= app_bundle
+
+SOURCES += tst_clicker.cpp
+
+RESOURCES += \
+        $$PWD/../src/qml.qrc
+
+INCLUDEPATH += $$PWD/../src
+
+QML2_IMPORT_PATH = $$PWD/../src/qml.qrc
+
+OTHER_FILES += \
+    tst_clicker.qml \
+    ClickerTest.qml

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/tst_clicker.cpp
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/tst_clicker.cpp
@@ -1,0 +1,2 @@
+#include <QtQuickTest/quicktest.h>
+QUICK_TEST_MAIN(tst_clicker)

--- a/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/tst_clicker.qml
+++ b/tmc-langs-qmake/src/test/resources/invalid_quick_project/test_runner/tst_clicker.qml
@@ -1,0 +1,24 @@
+import QtQuick 2.6
+import QtTest 1.0
+import QtQuick.Window 2.2
+
+Item {
+    id: container
+    width: 400
+    height: 400
+
+    TestCase {
+        id: clickTest
+        name: "tst_Clicker"
+        when: windowShown
+
+        SignalSpy {
+            id: spy
+        }
+    }
+
+    ClickerTest {
+
+    }
+
+}


### PR DESCRIPTION
- Test binary failed to create test output when testing an invalid Quick project, we only checked if the test output file existed
- Added test instructions and cleaned stuff up