### PR TITLE
Skip RPlugin tests if Rscript not installed

### DIFF
--- a/tmc-langs-r/src/test/java/fi/helsinki/cs/tmc/langs/r/RPluginTest.java
+++ b/tmc-langs-r/src/test/java/fi/helsinki/cs/tmc/langs/r/RPluginTest.java
@@ -31,6 +31,10 @@ public class RPluginTest {
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
+    public RPluginTest() {
+        TestUtils.skipIfNotAvailable("Rscript");
+    }
+
     @Before
     public void setUp() {
         plugin = new RPlugin();


### PR DESCRIPTION
I have one for `qmake` also