### PR TITLE
Use default system encoding when reading test result JSON-file (Python3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - source /opt/qt59/bin/qt59-env.sh
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
   - mkdir -p $HOME/bin && ln -s $(which python3.4) $HOME/bin/python3 && export PATH="$HOME/bin:$PATH"
-  - mvn install -Dmaven.test.skip=true
+  - mvn clean install -Dmaven.test.skip=true -q
 
 script:
   - mvn clean test -q

--- a/tmc-langs-framework/pom.xml
+++ b/tmc-langs-framework/pom.xml
@@ -80,6 +80,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-java/pom.xml
+++ b/tmc-langs-java/pom.xml
@@ -211,6 +211,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
             <plugin>

--- a/tmc-langs-make/pom.xml
+++ b/tmc-langs-make/pom.xml
@@ -68,6 +68,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-notests/pom.xml
+++ b/tmc-langs-notests/pom.xml
@@ -69,6 +69,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-python3/pom.xml
+++ b/tmc-langs-python3/pom.xml
@@ -68,6 +68,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-python3/src/main/java/fi/helsinki/cs/tmc/langs/python3/Python3TestResultParser.java
+++ b/tmc-langs-python3/src/main/java/fi/helsinki/cs/tmc/langs/python3/Python3TestResultParser.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -49,7 +50,8 @@ public final class Python3TestResultParser {
     }
 
     private List<TestResult> getTestResults() throws IOException {
-        byte[] json = Files.readAllBytes(path.resolve(RESULT_FILE));
+        String json = String.join("", Files.readAllLines(
+                path.resolve(RESULT_FILE), Charset.defaultCharset()));
         List<TestResult> results = new ArrayList<>();
 
         JsonNode tree = mapper.readTree(json);

--- a/tmc-langs-qmake/pom.xml
+++ b/tmc-langs-qmake/pom.xml
@@ -62,6 +62,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-rust/pom.xml
+++ b/tmc-langs-rust/pom.xml
@@ -62,6 +62,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The Python 3 test runner uses `.tmc_test_results.json` to report its results, the contents of which are written in the default system encoding. The corresponding parser on the Java side expects the content to be utf-8 encoded, which causes a parsing error on Windows systems when non-ASCII characters appear in the test results.

This patch solves the issue by reading the test result file using the default system encoding, which should match the one it was written in. The alternative solution of always having the Python 3 test runner write its results using the utf-8 encoding would require all exercises to be updated.

Finally, this solution could be made more robust by using an encoding detection library to find a compatible encoding, although that approach will result in false matches for some bytestrings. 