### PR TITLE
Be less verbose to not exceed Travis' log limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - source /opt/qt59/bin/qt59-env.sh
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
   - mkdir -p $HOME/bin && ln -s $(which python3.4) $HOME/bin/python3 && export PATH="$HOME/bin:$PATH"
-  - mvn install -Dmaven.test.skip=true
+  - mvn clean install -Dmaven.test.skip=true -q
 
 script:
   - mvn clean test -q

--- a/tmc-langs-framework/pom.xml
+++ b/tmc-langs-framework/pom.xml
@@ -80,6 +80,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-java/pom.xml
+++ b/tmc-langs-java/pom.xml
@@ -211,6 +211,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
             <plugin>

--- a/tmc-langs-make/pom.xml
+++ b/tmc-langs-make/pom.xml
@@ -68,6 +68,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-notests/pom.xml
+++ b/tmc-langs-notests/pom.xml
@@ -69,6 +69,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-python3/pom.xml
+++ b/tmc-langs-python3/pom.xml
@@ -68,6 +68,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-qmake/pom.xml
+++ b/tmc-langs-qmake/pom.xml
@@ -62,6 +62,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>

--- a/tmc-langs-rust/pom.xml
+++ b/tmc-langs-rust/pom.xml
@@ -62,6 +62,7 @@
                             <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
                     </archive>
+                    <forceCreation>true</forceCreation>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Added forceCreation to maven-jar-plugin to always re-create the jar files. This supposedly removes some of the warnings regarding overlapping classes in jar-files, as they might be compared to old versions of themselves (according to this StackOverflow answer: https://stackoverflow.com/a/15774766)