### PR TITLE
Parse test names, remove bool is not bool

### DIFF
--- a/tmc-langs-python3/src/main/java/fi/helsinki/cs/tmc/langs/python3/Python3TestResultParser.java
+++ b/tmc-langs-python3/src/main/java/fi/helsinki/cs/tmc/langs/python3/Python3TestResultParser.java
@@ -62,6 +62,22 @@ public final class Python3TestResultParser {
         return results;
     }
 
+    private String parseTestName(String testName) {
+        String[] parts = testName.split("\\.");
+        if (parts.length == 4) {
+            return parts[2] + ": " + parts[3];
+        }
+        return testName;
+    }
+
+    private String parseTestMessage(String testMessage) {
+        String matcher = testMessage.toLowerCase();
+        if (matcher.matches("^(true|false) is not (true|false) :[\\s\\S]*")) {
+            return testMessage.split(":")[1].trim();
+        }
+        return testMessage;
+    }
+
     private TestResult toTestResult(JsonNode node) {
         List<String> points = new ArrayList<>();
         for (JsonNode point : node.get("points")) {
@@ -74,10 +90,10 @@ public final class Python3TestResultParser {
         }
 
         return new TestResult(
-                node.get("name").asText(),
+                parseTestName(node.get("name").asText()),
                 node.get("passed").asBoolean(),
                 ImmutableList.copyOf(points),
-                node.get("message").asText(),
+                parseTestMessage(node.get("message").asText()),
                 ImmutableList.copyOf(backTrace));
     }
 }

--- a/tmc-langs-python3/src/test/java/fi/helsinki/cs/tmc/langs/python3/Python3PluginTest.java
+++ b/tmc-langs-python3/src/test/java/fi/helsinki/cs/tmc/langs/python3/Python3PluginTest.java
@@ -113,8 +113,15 @@ public class Python3PluginTest {
         assertFalse(testResult.isSuccessful());
         assertFalse(testResult.getMessage().isEmpty());
         assertEquals(6, testResult.getException().size());
+    }
 
-        testResult = runResult.testResults.get(1);
+    @Test
+    public void testFailingTestNoBoolIsBool() {
+        Path path = TestUtils.getPath(getClass(), "failparsing");
+        RunResult runResult = python3Plugin.runTests(path);
+
+        assertEquals(RunResult.Status.TESTS_FAILED, runResult.status);
+        TestResult testResult = runResult.testResults.get(0);
         assertEquals(
                 "No false is not true at beginning\n   newlines  are kept",
                 testResult.getMessage());

--- a/tmc-langs-python3/src/test/java/fi/helsinki/cs/tmc/langs/python3/Python3PluginTest.java
+++ b/tmc-langs-python3/src/test/java/fi/helsinki/cs/tmc/langs/python3/Python3PluginTest.java
@@ -2,6 +2,7 @@ package fi.helsinki.cs.tmc.langs.python3;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import fi.helsinki.cs.tmc.langs.abstraction.Strategy;
@@ -94,7 +95,8 @@ public class Python3PluginTest {
         assertEquals(RunResult.Status.PASSED, runResult.status);
         TestResult testResult = runResult.testResults.get(0);
         assertTrue(testResult.isSuccessful());
-        assertEquals("test.test_new.TestCase.test_new", testResult.getName());
+        assertNotEquals("test.test_new.TestCase.test_new", testResult.getName());
+        assertEquals("TestCase: test_new", testResult.getName());
         assertEquals(2, testResult.points.size());
         assertTrue(testResult.points.contains("1.2"));
         assertEquals("", testResult.getMessage());
@@ -111,6 +113,11 @@ public class Python3PluginTest {
         assertFalse(testResult.isSuccessful());
         assertFalse(testResult.getMessage().isEmpty());
         assertEquals(6, testResult.getException().size());
+
+        testResult = runResult.testResults.get(1);
+        assertEquals(
+                "No false is not true at beginning\n   newlines  are kept",
+                testResult.getMessage());
     }
 
     @Test

--- a/tmc-langs-python3/src/test/resources/failing/test/test_failing.py
+++ b/tmc-langs-python3/src/test/resources/failing/test/test_failing.py
@@ -8,5 +8,9 @@ class FailingTest(unittest.TestCase):
     def test_new(self):
         self.assertEqual("a", "b")
 
+    @points('1.2')
+    def test_two(self):
+        self.failIf(True, "No false is not true at beginning\n   newlines  are kept")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tmc-langs-python3/src/test/resources/failparsing/test/test_failparsing.py
+++ b/tmc-langs-python3/src/test/resources/failparsing/test/test_failparsing.py
@@ -2,11 +2,11 @@ import unittest
 from tmc import points
 
 
-class FailingTest(unittest.TestCase):
+class FailParsingTest(unittest.TestCase):
 
     @points('1.1')
     def test_new(self):
-        self.assertEqual("a", "b")
+        self.assertFalse(True, "No false is not true at beginning\n   newlines  are kept")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tmc-langs-python3/src/test/resources/failparsing/tmc/__init__.py
+++ b/tmc-langs-python3/src/test/resources/failparsing/tmc/__init__.py
@@ -1,0 +1,2 @@
+from .points import points
+from .runner import TMCTestRunner

--- a/tmc-langs-python3/src/test/resources/failparsing/tmc/__main__.py
+++ b/tmc-langs-python3/src/test/resources/failparsing/tmc/__main__.py
@@ -1,0 +1,11 @@
+from unittest import TestProgram
+from .runner import TMCTestRunner
+import sys
+
+
+if sys.argv.__len__() > 1 and sys.argv[1] == 'available_points':
+    TMCTestRunner().available_points()
+    sys.exit()
+
+main = TestProgram
+main(testRunner=TMCTestRunner, module=None, failfast=False)

--- a/tmc-langs-python3/src/test/resources/failparsing/tmc/points.py
+++ b/tmc-langs-python3/src/test/resources/failparsing/tmc/points.py
@@ -1,0 +1,50 @@
+from inspect import isclass, isfunction
+from collections import defaultdict
+
+point_register = {'suite': defaultdict(list), 'test': defaultdict(list)}
+
+
+def qualifier(test):
+    return "%s.%s" % (test.__module__, test.__qualname__)
+
+
+def save_points(o, points, dst):
+    q = qualifier(o)
+    dst[q] += filter(lambda point: point not in dst[q], points)
+
+
+def points(*points):
+
+    def points_wrapper(o):
+        if isclass(o):
+            save_points(o, points, point_register['suite'])
+        elif isfunction(o):
+            save_points(o, points, point_register['test'])
+        else:
+            raise Exception("Expected decorator object '%s' type to be Class or Function but was %s." % (o, type(o)))
+        return o
+
+    if not points:
+        raise Exception("You need to define at least one point in the points decorator declaration")
+    for point in points:
+        if type(point) is not str:
+            msg = "Points decorator argument '%s' needs to be a string, but was %s." % (point, type(point).__name__)
+            raise Exception(msg)
+    return points_wrapper
+
+
+def _parse_points(test):
+    name = _name_test(test)
+    testPoints = point_register['test']
+    points = testPoints[name]
+    key = name[:name.rfind('.')]
+    suitePoints = point_register['suite'][key]
+    points += suitePoints
+    return points
+
+
+def _name_test(test):
+    module = test.__module__
+    classname = test.__class__.__name__
+    testName = test._testMethodName
+    return module + '.' + classname + '.' + testName

--- a/tmc-langs-python3/src/test/resources/failparsing/tmc/result.py
+++ b/tmc-langs-python3/src/test/resources/failparsing/tmc/result.py
@@ -1,0 +1,52 @@
+from unittest.runner import TextTestResult
+from .points import _parse_points, _name_test
+import atexit
+import json
+import traceback
+
+results = []
+
+
+class TMCResult(TextTestResult):
+
+    def __init__(self, stream, descriptions, verbosity):
+        super(TMCResult, self).__init__(stream, descriptions, verbosity)
+
+    def startTest(self, test):
+        super(TMCResult, self).startTest(test)
+
+    def addSuccess(self, test):
+        super(TMCResult, self).addSuccess(test)
+        self.addResult(test, 'passed')
+
+    def addFailure(self, test, err):
+        super(TMCResult, self).addFailure(test, err)
+        self.addResult(test, 'failed', err)
+
+    def addError(self, test, err):
+        super(TMCResult, self).addError(test, err)
+        self.addResult(test, 'errored', err)
+
+    def addResult(self, test, status, err=None):
+        points = _parse_points(test)
+        message = ""
+        backtrace = []
+        if err is not None:
+            message = str(err[1])
+            backtrace = traceback.format_tb(err[2])
+
+        details = {
+            'name': _name_test(test),
+            'status': status,
+            'message': message,
+            'passed': status == 'passed',
+            'points': points,
+            'backtrace': backtrace
+        }
+        results.append(details)
+
+    # TODO: Do not do this if not using TMCTestRunner
+    @atexit.register
+    def write_output():
+        with open('.tmc_test_results.json', 'w') as f:
+            json.dump(results, f, ensure_ascii=False)

--- a/tmc-langs-python3/src/test/resources/failparsing/tmc/runner.py
+++ b/tmc-langs-python3/src/test/resources/failparsing/tmc/runner.py
@@ -1,0 +1,32 @@
+from unittest import TextTestRunner, TestLoader
+from .result import TMCResult
+from .points import _parse_points, _name_test
+from itertools import chain
+import json
+
+
+class TMCTestRunner(TextTestRunner):
+    """A test runner for TMC exercises.
+    """
+
+    resultclass = TMCResult
+
+    def __init__(self, *args, **kwargs):
+        super(TMCTestRunner, self).__init__(*args, **kwargs)
+
+    def run(self, test):
+        print('Running tests with some TMC magic...')
+        return super(TMCTestRunner, self).run(test)
+
+    def available_points(self):
+        testLoader = TestLoader()
+        tests = testLoader.discover('.', 'test*.py', None)
+        tests = list(chain(*chain(*tests._tests)))
+
+        points = map(_parse_points, tests)
+        names = map(_name_test, tests)
+
+        result = dict(zip(names, points))
+
+        with open('.available_points.json', 'w') as f:
+            json.dump(result, f, ensure_ascii=False)


### PR DESCRIPTION
This pull request adds some parsing to Python test results. For example, `test.test_viiva.ViivaTest.test_funktio_olemassa` will be stripped down to `ViivaTest: test_funktio_olemassa`

Any `False is not true` (and vice versa) will also be removed from the start of test messages.