### PR TITLE
Update C# runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - valgrind
       - check
       - python3.4
-      - dotnet-sdk-3.1
+      - dotnet-sdk-5.0
 env:
   global:
   - secure: yiW+hXiZEycKFzF19rLlejJX8BTGbncSisBHyE8uulZee5n7UVGXnG1yvt9+6hz0nvMbxL7r1Daql0xxRHXUFB9VYVUKhF0ycHyJO5ze87U51mlIKAL8UnCkmxpkHNdxY45olEdK+mEbZBtot67nenlwGDfxLI7laITkR8IBAvY=

--- a/tmc-langs-csharp/src/main/java/fi/helsinki/cs/tmc/langs/csharp/CSharpPlugin.java
+++ b/tmc-langs-csharp/src/main/java/fi/helsinki/cs/tmc/langs/csharp/CSharpPlugin.java
@@ -56,7 +56,7 @@ public class CSharpPlugin extends AbstractLanguagePlugin {
 
     private static final Path SRC_PATH = Paths.get("src");
     
-    public static final String RUNNER_ZIP_DOWNLOAD_VERSION = "1.0.1";
+    public static final String RUNNER_ZIP_DOWNLOAD_VERSION = "1.1";
     private static final String RUNNER_ZIP_DOWNLOAD_URL
             = "https://download.mooc.fi/tmc-csharp/tmc-csharp-runner-" 
             + RUNNER_ZIP_DOWNLOAD_VERSION + ".zip";

--- a/tmc-langs-csharp/src/test/resources/CleanUpProject/src/PassingSample/PassingSample.csproj
+++ b/tmc-langs-csharp/src/test/resources/CleanUpProject/src/PassingSample/PassingSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tmc-langs-csharp/src/test/resources/CleanUpProject/test/PassingSampleTests/PassingSampleTests.csproj
+++ b/tmc-langs-csharp/src/test/resources/CleanUpProject/test/PassingSampleTests/PassingSampleTests.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="TestMyCode.CSharp.API" Version="1.0.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="TestMyCode.CSharp.API" Version="1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tmc-langs-csharp/src/test/resources/FailingProject/src/FailingSample/FailingSample.csproj
+++ b/tmc-langs-csharp/src/test/resources/FailingProject/src/FailingSample/FailingSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tmc-langs-csharp/src/test/resources/FailingProject/test/FailingSampleTests/FailingSampleTests.csproj
+++ b/tmc-langs-csharp/src/test/resources/FailingProject/test/FailingSampleTests/FailingSampleTests.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="TestMyCode.CSharp.API" Version="1.0.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="TestMyCode.CSharp.API" Version="1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tmc-langs-csharp/src/test/resources/NonCompilingProject/src/NonCompilingSample/NonCompilingSample.csproj
+++ b/tmc-langs-csharp/src/test/resources/NonCompilingProject/src/NonCompilingSample/NonCompilingSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tmc-langs-csharp/src/test/resources/NonCompilingProject/test/NonCompilingSampleTests/NonCompilingSampleTests.csproj
+++ b/tmc-langs-csharp/src/test/resources/NonCompilingProject/test/NonCompilingSampleTests/NonCompilingSampleTests.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="TestMyCode.CSharp.API" Version="1.0.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="TestMyCode.CSharp.API" Version="1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tmc-langs-csharp/src/test/resources/PassingProject/src/PassingSample/PassingSample.csproj
+++ b/tmc-langs-csharp/src/test/resources/PassingProject/src/PassingSample/PassingSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tmc-langs-csharp/src/test/resources/PassingProject/test/PassingSampleTests/PassingSampleTests.csproj
+++ b/tmc-langs-csharp/src/test/resources/PassingProject/test/PassingSampleTests/PassingSampleTests.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="TestMyCode.CSharp.API" Version="1.0.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="TestMyCode.CSharp.API" Version="1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tmc-langs-csharp/src/test/resources/PolicyProject/src/PolicySample/PolicySample.csproj
+++ b/tmc-langs-csharp/src/test/resources/PolicyProject/src/PolicySample/PolicySample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tmc-langs-csharp/src/test/resources/PolicyProject/test/PolicySampleTests/PolicySamplTests.csproj
+++ b/tmc-langs-csharp/src/test/resources/PolicyProject/test/PolicySampleTests/PolicySamplTests.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="TestMyCode.CSharp.API" Version="1.0.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="TestMyCode.CSharp.API" Version="1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
C# runner now supports .NET 5

Also change the tests to use .NET 5 so there's no need to install .NET Core 3.1